### PR TITLE
feat: use buffer package

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+This fork adds the [buffer](https://www.npmjs.com/package/buffer) package as a dependency. That removes the requirement to configure polyfills for browser builds.
+
 This is a streaming JSON parser.  For a simpler, sax-based version see this gist: https://gist.github.com/1821394
 
 The MIT License (MIT)

--- a/jsonparse.js
+++ b/jsonparse.js
@@ -1,4 +1,4 @@
-/*global Buffer*/
+var { Buffer } = require('buffer')
 // Named constants with unique integer values
 var C = {};
 // Tokens

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "jsonparse",
+  "name": "@bergos/jsonparse",
   "description": "This is a pure-js JSON streaming parser for node.js",
-  "tags": ["json", "stream"],
+  "tags": [
+    "json",
+    "stream"
+  ],
   "version": "1.3.1",
   "author": "Tim Caswell <tim@creationix.com>",
   "repository": {
@@ -9,14 +12,19 @@
     "url": "http://github.com/creationix/jsonparse.git"
   },
   "devDependencies": {
-    "tape": "~0.1.1",
-    "tap": "~0.3.3"
+    "tap": "~0.3.3",
+    "tape": "~0.1.1"
   },
   "scripts": {
     "test": "tap test/*.js"
   },
   "bugs": "http://github.com/creationix/jsonparse/issues",
-  "engines": ["node >= 0.2.0"],
+  "engines": [
+    "node >= 0.2.0"
+  ],
   "license": "MIT",
-  "main": "jsonparse.js"
+  "main": "jsonparse.js",
+  "dependencies": {
+    "buffer": "^6.0.3"
+  }
 }


### PR DESCRIPTION
This fork adds the [buffer](https://www.npmjs.com/package/buffer) package as a dependency. That removes the requirement to configure polyfills for browser builds.