### PR TITLE
Add required parameters to numberReviver function

### DIFF
--- a/jsonparse.js
+++ b/jsonparse.js
@@ -265,7 +265,7 @@ proto.write = function (buffer) {
             break;
           default:
             this.tState = START;
-            var error = this.numberReviver(this.string);
+            var error = this.numberReviver(this.string, buffer, i);
             if (error){
               return error;
             }
@@ -406,7 +406,7 @@ proto.onToken = function (token, value) {
 
 // Override to implement your own number reviver.
 // Any value returned is treated as error and will interrupt parsing.
-proto.numberReviver = function (text) {
+proto.numberReviver = function (text, buffer, i) {
   var result = Number(text);
 
   if (isNaN(result)) {


### PR DESCRIPTION
The `numberReviver` function calls the `charError` call in case it gets invalid input. But it tries to do that with parameters that are not provided to the function, causing the parser to crash with `ReferenceError: i is not defined`. This PR resolves that.

Call happens here: https://github.com/bergos/jsonparse/blob/357f8ff735597d6714040843dd9c5bb502662162/jsonparse.js#L409-L414